### PR TITLE
Fix README and use more stable base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM openjdk:8u151-jre-alpine
-MAINTAINER meetup.com
-LABEL Description="A simple containerization of giter8. https://github.com/moredip/giter8"
+FROM openjdk:8u161-jre-alpine
+LABEL org.label-schema.schema-version = "1.0"
+LABEL org.label-schema.description = "A simple containerization of giter8. https://github.com/moredip/giter8"
+LABEL org.label-schema.vcs-url = "https://github.com/avast/giter8-docker-image"
 
 RUN apk --update add curl ca-certificates openssl bash
 ENV CONSCRIPT_HOME /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u161-jre-alpine
+FROM openjdk:8u151-jre-alpine
 LABEL org.label-schema.schema-version = "1.0"
 LABEL org.label-schema.description = "A simple containerization of giter8. https://github.com/moredip/giter8"
 LABEL org.label-schema.vcs-url = "https://github.com/avast/giter8-docker-image"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u151-jre-alpine
 MAINTAINER meetup.com
 LABEL Description="A simple containerization of giter8. https://github.com/moredip/giter8"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # giter8 docker image
 
-[Giter8](https://github.com/n8han/giter8) command line tool wrapped to Docker image.
+[Giter8](https://github.com/n8han/giter8) command-line tool wrapped to Docker image.
 
 To use it:
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ A simple containerization of [giter8](https://github.com/n8han/giter8).
 
 To use it:
 ```
-docker run -v $PWD:/g8out meetup/g8 softprops/unfiltered.g8 --name=my-new-website
+docker run -v $PWD:/g8out meetup/g8 unfiltered/unfiltered.g8 --name=my-new-website
 ```
 
-This will take generate a new `my-new-website` project based on the [`softprops/unfiltered.g8`](https://github.com/softprops/unfiltered.g8) template and place it in `my-new-website` under the current directory.
+This will take generate a new `my-new-website` project based on the [`unfiltered/unfiltered.g8`](https://github.com/unfiltered/unfiltered.g8) template and place it in `my-new-website` under the current directory.
+
+Or you can set the project properties interactivelly:
+```
+> docker run -v $PWD:/g8out -it meetup/g8 unfiltered/unfiltered.g8
+
+This template generates an Unfiltered project
+
+name [My Web Project]: my-new-website
+version [0.1.0-SNAPSHOT]:
+scala_version [2.12.4]:
+sbt_version [1.1.0]:
+unfiltered_version [0.9.1]:
+
+Template applied in /g8out/./my-new-website
+```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # giter8 docker image
 
-A simple containerization of [giter8](https://github.com/n8han/giter8). 
+[Giter8](https://github.com/n8han/giter8) command line tool wrapped to Docker image.
 
 To use it:
 ```
-docker run -v $PWD:/g8out meetup/g8 unfiltered/unfiltered.g8 --name=my-new-website
+docker run --rm -v $PWD:/g8out avastsoftware/g8 unfiltered/unfiltered.g8 --name=my-new-website
 ```
 
 This will take generate a new `my-new-website` project based on the [`unfiltered/unfiltered.g8`](https://github.com/unfiltered/unfiltered.g8) template and place it in `my-new-website` under the current directory.
 
 Or you can set the project properties interactivelly:
 ```
-> docker run -v $PWD:/g8out -it meetup/g8 unfiltered/unfiltered.g8
+> docker run --rm -v $PWD:/g8out -it avastsoftware/g8 unfiltered/unfiltered.g8
 
 This template generates an Unfiltered project
 


### PR DESCRIPTION
The example in the README produces this output:
```
ls() function is deprecated. Use maven() function to get latest version of unfiltered.
```
The problem is that `softprops/unfiltered.g8` repository is too old and the template is not valid anymore. So I've updated the README to use `unfiltered/unfiltered.g8` instead.

I've also added to README information about how to run the Docker image in interactive mode.